### PR TITLE
Rename ConfigMap name in example nodelist-generator.sh

### DIFF
--- a/adaptors/loopback/examples/nodelist-generator.sh
+++ b/adaptors/loopback/examples/nodelist-generator.sh
@@ -26,7 +26,7 @@ function header {
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: nodelist
+  name: loopback-adaptor-nodelist
   namespace: oran-hwmgr-plugin
 data:
   resources: |


### PR DESCRIPTION
This MR renames the ConfigMap in example nodelist-generator script to match new plugin name 'loopback-adaptor-plugin'