### PR TITLE
CNF-15609: Enhance Loopback Plugin for Node Pool Configuration Changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,9 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
+ifeq ($(shell uname -s),Linux)
 	@chmod -R u+w $(LOCALBIN)
+endif
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: operator-sdk
@@ -336,7 +338,9 @@ catalog-push: ## Push a catalog image.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
+ifeq ($(shell uname -s),Linux)
 	@chmod -R u+w $(LOCALBIN)
+endif
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.

--- a/adaptors/loopback/README.md
+++ b/adaptors/loopback/README.md
@@ -169,12 +169,12 @@ data:
         master:
         - dummy-sp-64g-1
   resources: |
-    hwprofiles:
-      - profile-spr-dual-processor-128G
-      - profile-spr-single-processor-64G
+    resourcepools:
+      - master
+      - worker
     nodes:
       dummy-dp-128g-0:
-        hwprofile: profile-spr-dual-processor-128G
+        poolID: worker
         bmc:
           address: "idrac-virtualmedia+https://192.168.1.0/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -185,7 +185,7 @@ data:
             macAddress: "c6:b6:13:a0:01:00"
         hostname: "dummy-dp-128g-0.localhost"
       dummy-dp-128g-1:
-        hwprofile: profile-spr-dual-processor-128G
+        poolID: worker
         bmc:
           address: "idrac-virtualmedia+https://192.168.1.1/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -196,7 +196,7 @@ data:
             macAddress: "c6:b6:13:a0:01:01"
         hostname: "dummy-dp-128g-1.localhost"
       dummy-dp-128g-2:
-        hwprofile: profile-spr-dual-processor-128G
+        poolID: worker
         bmc:
           address: "idrac-virtualmedia+https://192.168.1.2/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -207,7 +207,7 @@ data:
             macAddress: "c6:b6:13:a0:01:02"
         hostname: "dummy-dp-128g-2.localhost"
       dummy-sp-64g-0:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.0/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -218,7 +218,7 @@ data:
             macAddress: "c6:b6:13:a0:02:00"
         hostname: "dummy-sp-64g-0.localhost"
       dummy-sp-64g-1:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.1/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -229,7 +229,7 @@ data:
             macAddress: "c6:b6:13:a0:02:01"
         hostname: "dummy-sp-64g-1.localhost"
       dummy-sp-64g-2:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.2/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -240,7 +240,7 @@ data:
             macAddress: "c6:b6:13:a0:02:02"
         hostname: "dummy-sp-64g-2.localhost"
       dummy-sp-64g-3:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.3/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -251,7 +251,7 @@ data:
             macAddress: "c6:b6:13:a0:02:03"
         hostname: "dummy-sp-64g-3.localhost"
       dummy-sp-64g-4:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.4/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=

--- a/adaptors/loopback/examples/example-nodelist.yaml
+++ b/adaptors/loopback/examples/example-nodelist.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: oran-hwmgr-plugin
 data:
   resources: |
-    hwprofiles:
-      - profile-spr-dual-processor-128G
-      - profile-spr-single-processor-64G
+    resourcepools:
+      - master
+      - worker
     nodes:
       dummy-dp-128g-0:
-        hwprofile: profile-spr-dual-processor-128G
+        poolID: worker
         bmc:
           address: "idrac-virtualmedia+https://192.168.1.0/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -21,7 +21,7 @@ data:
             macAddress: "c6:b6:13:a0:01:00"
         hostname: "dummy-dp-128g-0.localhost"
       dummy-dp-128g-1:
-        hwprofile: profile-spr-dual-processor-128G
+        poolID: worker
         bmc:
           address: "idrac-virtualmedia+https://192.168.1.1/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -32,7 +32,7 @@ data:
             macAddress: "c6:b6:13:a0:01:01"
         hostname: "dummy-dp-128g-1.localhost"
       dummy-dp-128g-2:
-        hwprofile: profile-spr-dual-processor-128G
+        poolID: worker
         bmc:
           address: "idrac-virtualmedia+https://192.168.1.2/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -43,7 +43,7 @@ data:
             macAddress: "c6:b6:13:a0:01:02"
         hostname: "dummy-dp-128g-2.localhost"
       dummy-sp-64g-0:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.0/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -54,7 +54,7 @@ data:
             macAddress: "c6:b6:13:a0:02:00"
         hostname: "dummy-sp-64g-0.localhost"
       dummy-sp-64g-1:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.1/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -65,7 +65,7 @@ data:
             macAddress: "c6:b6:13:a0:02:01"
         hostname: "dummy-sp-64g-1.localhost"
       dummy-sp-64g-2:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.2/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -76,7 +76,7 @@ data:
             macAddress: "c6:b6:13:a0:02:02"
         hostname: "dummy-sp-64g-2.localhost"
       dummy-sp-64g-3:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.3/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -87,7 +87,7 @@ data:
             macAddress: "c6:b6:13:a0:02:03"
         hostname: "dummy-sp-64g-3.localhost"
       dummy-sp-64g-4:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.4/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=

--- a/internal/controller/utils/nodepool_utils.go
+++ b/internal/controller/utils/nodepool_utils.go
@@ -69,50 +69,21 @@ func UpdateNodePoolStatusCondition(
 		conditionStatus,
 		message)
 
-	// nolint: wrapcheck
-	err := RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
-		newNodepool := &hwmgmtv1alpha1.NodePool{}
-		if err := c.Get(ctx, client.ObjectKeyFromObject(nodepool), newNodepool); err != nil {
-			return err
-		}
-		SetStatusCondition(&newNodepool.Status.Conditions,
-			string(conditionType),
-			string(conditionReason),
-			conditionStatus,
-			message)
-		if err := c.Status().Update(ctx, newNodepool); err != nil {
-			return err
-		}
-		return nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed to update nodepool condition: %w", err)
+	if err := UpdateK8sCRStatus(ctx, c, nodepool); err != nil {
+		return fmt.Errorf("failed to update nodepool condition %s: %w", nodepool.Name, err)
 	}
 
 	return nil
 }
 
-func UpdateNodePoolProperties(
+func UpdateNodePoolPluginStatus(
 	ctx context.Context,
 	c client.Client,
 	nodepool *hwmgmtv1alpha1.NodePool) error {
 
-	// nolint: wrapcheck
-	err := RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
-		newNodepool := &hwmgmtv1alpha1.NodePool{}
-		if err := c.Get(ctx, client.ObjectKeyFromObject(nodepool), newNodepool); err != nil {
-			return err
-		}
-		newNodepool.Status.Properties = nodepool.Status.Properties
-		if err := c.Status().Update(ctx, newNodepool); err != nil {
-			return err
-		}
-		return nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed to update nodepool condition: %w", err)
+	nodepool.Status.HwMgrPlugin.ObservedGeneration = nodepool.ObjectMeta.Generation
+	if err := UpdateK8sCRStatus(ctx, c, nodepool); err != nil {
+		return fmt.Errorf("failed to update nodepool status %s: %w", nodepool.Name, err)
 	}
 
 	return nil

--- a/test/reconcile/assets/manifests/loopback-nodelist-cm.yaml
+++ b/test/reconcile/assets/manifests/loopback-nodelist-cm.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: default
 data:
   resources: |
-    hwprofiles:
-      - profile-spr-dual-processor-128G
-      - profile-spr-single-processor-64G
+    resourcepools:
+      - worker
+      - master
     nodes:
       dummy-sp-64g-0:
-        hwprofile: profile-spr-single-processor-64G
+        poolID: master
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.0/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=
@@ -21,7 +21,7 @@ data:
             macAddress: "c6:b6:13:a0:02:00"
         hostname: "dummy-sp-64g-0.localhost"
       dummy-sp-128g-0:
-        hwprofile: profile-spr-dual-processor-128G
+        poolID: worker
         bmc:
           address: "idrac-virtualmedia+https://192.168.2.1/redfish/v1/Systems/System.Embedded.1"
           username-base64: YWRtaW4=


### PR DESCRIPTION
This update introduces enhancements to the loopback plugin to support configuration changes in Node Pools. 
Key modifications include:

1. Restructure Node List ConfigMap: 
The ConfigMap structure has been updated to use resourcePools instead of hwProfiles. Now, the ConfigMap includes a list of resource pools, with each configured node specifying its associated pool, enabling node allocation based on resourcePool rather than hwProfile.

3. NodePool Configuration Handling:
Stage 1 - Initiate Upgrades: The plugin identifies nodes requiring an upgrade and updates their Spec.HwProfile to the desired hardware profile. 
Stage 2 - Verify and Track Completion: The plugin monitors each node’s upgrade progress by comparing Status.HwProfile to Spec.HwProfile. Matching profiles indicate that the upgrade is complete, while discrepancies mean the process is still ongoing.