### PR TITLE
Rollback NodePool Status Update Retry Mechanism

### DIFF
--- a/adaptors/loopback/nodepool.go
+++ b/adaptors/loopback/nodepool.go
@@ -110,7 +110,7 @@ func (a *Adaptor) HandleNodePoolProcessing(
 	}
 	nodepool.Status.Properties.NodeNames = allocatedNodes
 
-	if err := utils.UpdateK8sCRStatus(ctx, a.Client, nodepool); err != nil {
+	if err := utils.UpdateNodePoolProperties(ctx, a.Client, nodepool); err != nil {
 		return utils.RequeueWithMediumInterval(),
 			fmt.Errorf("failed to update status for NodePool %s: %w", nodepool.Name, err)
 	}

--- a/internal/controller/utils/nodepool_utils.go
+++ b/internal/controller/utils/nodepool_utils.go
@@ -69,8 +69,50 @@ func UpdateNodePoolStatusCondition(
 		conditionStatus,
 		message)
 
-	if err := UpdateK8sCRStatus(ctx, c, nodepool); err != nil {
-		return fmt.Errorf("failed to update nodepool condition %s: %w", nodepool.Name, err)
+	// nolint: wrapcheck
+	err := RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
+		newNodepool := &hwmgmtv1alpha1.NodePool{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(nodepool), newNodepool); err != nil {
+			return err
+		}
+		SetStatusCondition(&newNodepool.Status.Conditions,
+			string(conditionType),
+			string(conditionReason),
+			conditionStatus,
+			message)
+		if err := c.Status().Update(ctx, newNodepool); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to update nodepool condition: %s, %w", nodepool.Name, err)
+	}
+
+	return nil
+}
+
+func UpdateNodePoolProperties(
+	ctx context.Context,
+	c client.Client,
+	nodepool *hwmgmtv1alpha1.NodePool) error {
+
+	// nolint: wrapcheck
+	err := RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
+		newNodepool := &hwmgmtv1alpha1.NodePool{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(nodepool), newNodepool); err != nil {
+			return err
+		}
+		newNodepool.Status.Properties = nodepool.Status.Properties
+		if err := c.Status().Update(ctx, newNodepool); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to update nodepool condition: %w", err)
 	}
 
 	return nil
@@ -81,9 +123,21 @@ func UpdateNodePoolPluginStatus(
 	c client.Client,
 	nodepool *hwmgmtv1alpha1.NodePool) error {
 
-	nodepool.Status.HwMgrPlugin.ObservedGeneration = nodepool.ObjectMeta.Generation
-	if err := UpdateK8sCRStatus(ctx, c, nodepool); err != nil {
-		return fmt.Errorf("failed to update nodepool status %s: %w", nodepool.Name, err)
+	// nolint: wrapcheck
+	err := RetryOnConflictOrRetriable(retry.DefaultRetry, func() error {
+		newNodepool := &hwmgmtv1alpha1.NodePool{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(nodepool), newNodepool); err != nil {
+			return err
+		}
+		newNodepool.Status.HwMgrPlugin.ObservedGeneration = newNodepool.ObjectMeta.Generation
+		if err := c.Status().Update(ctx, newNodepool); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to update nodepool condition: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This update rolls back the previously implemented retry mechanism for updating the NodePool status. Since the IMS updates the NodePool's spec and metadata fields, conflicts can still occur if the NodePool status update is attempted on an outdated version of the resource.
