### PR TITLE
upgrade golangci-lint to 1.62.2

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -96,5 +96,5 @@ jobs:
     - name: Run the linter
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.59.1
+        version: v1.62.2
         args: --timeout=5m

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.59.1"
+VERSION="1.62.2"
 
 rootdir=$(git rev-parse --show-toplevel)
 if [ -z "${rootdir}" ]; then


### PR DESCRIPTION
Memory management problems were caused to some folks with the current version, fixed with this latest version. Cc: @donpenney @mlguerrero12 