### PR TITLE
Enhance Dell plugin for Node Pool configuration changes

### DIFF
--- a/adaptors/dell-hwmgr/adaptor.go
+++ b/adaptors/dell-hwmgr/adaptor.go
@@ -72,6 +72,7 @@ type fsmAction int
 const (
 	NodePoolFSMCreate = iota
 	NodePoolFSMProcessing
+	NodePoolFSMSpecChanged
 	NodePoolFSMNoop
 )
 
@@ -84,14 +85,20 @@ func (a *Adaptor) determineAction(ctx context.Context, nodepool *hwmgmtv1alpha1.
 	provisionedCondition := meta.FindStatusCondition(
 		nodepool.Status.Conditions,
 		string(hwmgmtv1alpha1.Provisioned))
+
 	if provisionedCondition != nil {
-		if provisionedCondition.Reason == string(hwmgmtv1alpha1.Failed) {
-			a.Logger.InfoContext(ctx, "NodePool request in Failed state")
+		if provisionedCondition.Status == metav1.ConditionTrue {
+			// Check if the generation has changed
+			if nodepool.ObjectMeta.Generation != nodepool.Status.HwMgrPlugin.ObservedGeneration {
+				a.Logger.InfoContext(ctx, "Handling NodePool Spec change, name="+nodepool.Name)
+				return NodePoolFSMSpecChanged
+			}
+			a.Logger.InfoContext(ctx, "NodePool request in Provisioned state, name="+nodepool.Name)
 			return NodePoolFSMNoop
 		}
 
-		if provisionedCondition.Status == metav1.ConditionTrue {
-			a.Logger.InfoContext(ctx, "NodePool request in Provisioned state")
+		if provisionedCondition.Reason == string(hwmgmtv1alpha1.Failed) {
+			a.Logger.InfoContext(ctx, "NodePool request in Failed state"+nodepool.Name)
 			return NodePoolFSMNoop
 		}
 
@@ -116,6 +123,8 @@ func (a *Adaptor) HandleNodePool(ctx context.Context, hwmgr *pluginv1alpha1.Hard
 		return a.HandleNodePoolCreate(ctx, hwmgrClient, hwmgr, nodepool)
 	case NodePoolFSMProcessing:
 		return a.HandleNodePoolProcessing(ctx, hwmgrClient, hwmgr, nodepool)
+	case NodePoolFSMSpecChanged:
+		return a.HandleNodePoolSpecChanged(ctx, hwmgrClient, hwmgr, nodepool)
 	case NodePoolFSMNoop:
 		// Nothing to do
 		return result, nil

--- a/adaptors/loopback/nodepool.go
+++ b/adaptors/loopback/nodepool.go
@@ -147,7 +147,7 @@ func (a *Adaptor) checkNodeUpgradeProcess(
 
 	for _, name := range allocatedNodes {
 		// Fetch the latest version of each node to ensure up-to-date status
-		updatedNode, err := a.GetNode(ctx, name)
+		updatedNode, err := utils.GetNode(ctx, a.Client, a.Namespace, name)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get node %s: %w", name, err)
 		}
@@ -183,7 +183,7 @@ func (a *Adaptor) handleNodePoolConfiguring(
 
 	// Stage 1: Initiate upgrades by updating node.Spec.HwProfile as necessary
 	for _, name := range allocatedNodes {
-		node, err := a.GetNode(ctx, name)
+		node, err := utils.GetNode(ctx, a.Client, a.Namespace, name)
 		if err != nil {
 			return utils.RequeueWithShortInterval(), err
 		}

--- a/internal/controller/utils/node_utils.go
+++ b/internal/controller/utils/node_utils.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	hwmgmtv1alpha1 "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// GetNode get a node resource for a provided name
+func GetNode(ctx context.Context, c client.Client, namespace, nodename string) (*hwmgmtv1alpha1.Node, error) {
+
+	log := logf.FromContext(ctx)
+	log.Info(fmt.Sprintf("Getting Node:%s", nodename))
+
+	node := &hwmgmtv1alpha1.Node{}
+
+	if err := RetryOnConflictOrRetriableOrNotFound(retry.DefaultRetry, func() error {
+		return c.Get(ctx, types.NamespacedName{Name: nodename, Namespace: namespace}, node)
+	}); err != nil {
+		return node, fmt.Errorf("failed to get Node for update: %w", err)
+	}
+	return node, nil
+}


### PR DESCRIPTION
This is a copycat of @tliu2021 's existing changes on the loopback side, now on the Dell side.

Those changes were introduced with this commit on the loopback side : https://github.com/openshift-kni/oran-hwmgr-plugin/pull/23 and additionally, we have included the corresponding Dell logic to these two ones already present on the loopback side too: https://github.com/openshift-kni/oran-hwmgr-plugin/pull/31 and https://github.com/openshift-kni/oran-hwmgr-plugin/pull/35.

These items require specific feedback by the reviewers - @donpenney - :

- Dell `GetAllocatedNodes(...)` assumes all the nodes are allocated from the NodePool, instead of sending a request to the dtias. There is an explicit TODO comment [here](https://github.com/openshift-kni/oran-hwmgr-plugin/pull/37/files#diff-eacd20007863de534e028dca2429fa19b9cdd37fd2bc4fbb74f109ab4740cc42R344) . I might change this if we need to send a rest request to dtias.

- Dell `CreateNode(...)` assumes the hwprofile (ResourceProfileID) returned by the dtias might be empty. I have seen this might be not correct, according to Don's example today in the demo, where the 'resource' field was containing this profile. There is an explicit TODO comment [here](https://github.com/openshift-kni/oran-hwmgr-plugin/pull/37/files#diff-7fce2671b5a915e0caa55fe0ad9c20b189ddec71e2340373d4b9b1819ced5eeeR232) . I might remove this if it is not needed then

Overall, I see there is fairly common logic between the loopback and Dell adaptors to deal with these nodepool changes. It might make sense to create a new .go to deal with this common logic used by both adaptors instead of duplicating as this MR is currently doing. Let me know if this makes sense and I might try to merge @tliu2021 's changes and these ones in a common .go for both adaptors.