### PR TITLE
set automatic deletion (NP ownerreference) for secrets and nodes

### DIFF
--- a/adaptors/loopback/nodepool.go
+++ b/adaptors/loopback/nodepool.go
@@ -353,18 +353,6 @@ func (a *Adaptor) ReleaseNodePool(ctx context.Context,
 		return nil
 	}
 
-	for groupname := range allocations.Clouds[index].Nodegroups {
-		for _, nodename := range allocations.Clouds[index].Nodegroups[groupname] {
-			if err := a.DeleteBMCSecret(ctx, nodename); err != nil {
-				return fmt.Errorf("failed to delete bmc-secret for %s: %w", nodename, err)
-			}
-
-			if err := a.DeleteNode(ctx, nodename); err != nil {
-				return fmt.Errorf("failed to delete node %s: %w", nodename, err)
-			}
-		}
-	}
-
 	allocations.Clouds = slices.Delete[[]cmAllocatedCloud](allocations.Clouds, index, index+1)
 
 	// Update the configmap

--- a/test/adaptors/loopback/suite_test.go
+++ b/test/adaptors/loopback/suite_test.go
@@ -123,8 +123,8 @@ var _ = BeforeSuite(func() {
 
 	// build the adaptor controller
 	hwmgrAdaptor := &adaptors.HwMgrAdaptorController{
-		Client:    k8sClient,
-		Scheme:    k8sClient.Scheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
 		Logger:    logger,
 		Namespace: "default",
 	}
@@ -134,8 +134,8 @@ var _ = BeforeSuite(func() {
 
 	// build the hardware manager reconciler
 	nodepoolReconciler := o2imshardwaremanagement.NodePoolReconciler{
-		Client:       k8sClient,
-		Scheme:       k8sClient.Scheme(),
+		Client:       mgr.GetClient(),
+		Scheme:       mgr.GetScheme(),
 		Logger:       logger,
 		Namespace:    "default",
 		HwMgrAdaptor: hwmgrAdaptor,
@@ -164,5 +164,4 @@ var _ = AfterSuite(func() {
 		err := testEnv.Stop()
 		Expect(err).NotTo(HaveOccurred())
 	}
-
 })


### PR DESCRIPTION
This MR mimics the current Dell adaptor behaviour on the loopback side for the deletion of 'nodes' and 'secrets': they will be automatically deleted when the ownerReference (NodePool) is deleted. No explicit call to 'delete' is necessary to delete those objects from now on.

The loopback test has been modified to include the expected behaviour when the NodePool is deleted: 'secrets' and 'nodes' must be deleted then. Notice that our test automation - `make test` -  is based on 'envtest' and there is no actual garbage collection because there are no controllers - just our operator - monitoring resources; objects do not get actually deleted, even if an OwnerReference is set up.

The test only checks those OwnerReferences are properly configured then. 

As a side note, I spent a great deal of time debugging the test, as the NodePool 'apiVersion' and 'kind' were empty strings when performing a 'get' for those fields - the rest of the fields were perfectly fine - . This has to do with the procedure to scaffold an operator (manager and reconcilers) and I had to change that on the test side too to re-use the client the manager has, as the actual code does.