### PR TITLE
NO-ISSUE: Configure dependabot to ignore k8s.io major/minor updates for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
   ignore:
     # the oran-o2ims version is hand-managed
     - dependency-name: "github.com/openshift-kni/oran-o2ims/api/hardwaremanagement"
+    # k8s.io moved to go 1.23 in v0.32, so ignore major/minor updates until this repo is 1.23-based
+    - dependency-name: "k8s.io/*"
+      update-types: ["version-update:semver-major","version-update:semver-minor"]
   #ignore:
   #  - dependency-name: "*"
   #    update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
The major/minor updates for k8s.io repos require go 1.23. This update adds an `ignore` for such updates for dependabot, which can be removed when the plugin is updated to 1.23 as well