### PR TITLE
Remove Node and NodePool CRD dependencies from CSV

### DIFF
--- a/bundle/manifests/oran-hwmgr-plugin.clusterserviceversion.yaml
+++ b/bundle/manifests/oran-hwmgr-plugin.clusterserviceversion.yaml
@@ -96,13 +96,6 @@ spec:
         displayName: Resource Pools
         path: resourcePools
       version: v1alpha1
-    required:
-    - kind: NodePool
-      name: nodepools.o2ims-hardwaremanagement.oran.openshift.io
-      version: v1alpha1
-    - kind: Node
-      name: nodes.o2ims-hardwaremanagement.oran.openshift.io
-      version: v1alpha1
   description: O-Cloud Hardware Manager Plugin
   displayName: O-Cloud Hardware Manager Plugin
   icon:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -160,6 +160,7 @@ func main() {
 	}
 
 	if err = (&o2imshardwaremanagementcontroller.NodePoolReconciler{
+		Manager:      mgr,
 		Client:       mgr.GetClient(),
 		Scheme:       mgr.GetScheme(),
 		Logger:       slog.New(logging.NewLoggingContextHandler(slog.LevelInfo)).With("controller", "NodePool"),

--- a/config/manifests/bases/oran-hwmgr-plugin.clusterserviceversion.yaml
+++ b/config/manifests/bases/oran-hwmgr-plugin.clusterserviceversion.yaml
@@ -71,13 +71,6 @@ spec:
         displayName: Resource Pools
         path: resourcePools
       version: v1alpha1
-    required:
-    - kind: NodePool
-      name: nodepools.o2ims-hardwaremanagement.oran.openshift.io
-      version: v1alpha1
-    - kind: Node
-      name: nodes.o2ims-hardwaremanagement.oran.openshift.io
-      version: v1alpha1
   description: O-Cloud Hardware Manager Plugin
   displayName: O-Cloud Hardware Manager Plugin
   icon:

--- a/test/adaptors/loopback/suite_test.go
+++ b/test/adaptors/loopback/suite_test.go
@@ -134,6 +134,7 @@ var _ = BeforeSuite(func() {
 
 	// build the hardware manager reconciler
 	nodepoolReconciler := o2imshardwaremanagement.NodePoolReconciler{
+		Manager:      mgr,
 		Client:       mgr.GetClient(),
 		Scheme:       mgr.GetScheme(),
 		Logger:       logger,


### PR DESCRIPTION
The explicit dependencies set in the CSV against the Node and NodePool CRDs provided by the IMS ensure these CRDs get installed by OLM, but causes other issues with the subscription-based installs. These dependencies have now been removed.

In order to allow the plugin operator to come up into a Ready state without these CRDs installed, the Node indexer setup has been moved inside the NodePool CRD reconciler. The plugin operator will now retry starting the workers until the NodePool CRD has been installed, rather than failing pod creation.