### PR TITLE
CNF-16452: Fix inventory client package name

### DIFF
--- a/pkg/inventory-client/go.mod
+++ b/pkg/inventory-client/go.mod
@@ -1,4 +1,4 @@
-module client
+module github.com/openshift-kni/oran-hwmgr-plugin/pkg/inventory-client
 
 go 1.22
 


### PR DESCRIPTION
The go.mod declared the package as "client" rather than the fully qualified package name.