### PR TITLE
Update handling of deletion job check

### DIFF
--- a/adaptors/dell-hwmgr/generated/client.go
+++ b/adaptors/dell-hwmgr/generated/client.go
@@ -3416,7 +3416,7 @@ type VerifyRequestStatusResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *RhprotoJobStatus
-	JSONDefault  *RhprotoGooglerpcStatus
+	JSONDefault  *GooglerpcStatus
 }
 
 // Status returns HTTPResponse.Status
@@ -4708,7 +4708,7 @@ func ParseVerifyRequestStatusResponse(rsp *http.Response) (*VerifyRequestStatusR
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest RhprotoGooglerpcStatus
+		var dest GooglerpcStatus
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/adaptors/dell-hwmgr/hwmgrclient/client.go
+++ b/adaptors/dell-hwmgr/hwmgrclient/client.go
@@ -375,7 +375,7 @@ func (c *HardwareManagerClient) CheckJobStatus(ctx context.Context, jobId string
 	}
 
 	if response.StatusCode() != http.StatusOK {
-		return JobStatusUnknown, failReason, fmt.Errorf("job query failed for %s: %s", jobId, *response.JSONDefault.Message)
+		return JobStatusUnknown, failReason, fmt.Errorf("job query failed for %s: %s, body=%s", jobId, *response.JSONDefault.Message, string(response.Body))
 	}
 
 	status := response.JSON200

--- a/internal/controller/utils/nodepool_utils.go
+++ b/internal/controller/utils/nodepool_utils.go
@@ -193,7 +193,7 @@ func NodepoolAddFinalizer(
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to remove finalizer from nodepool: %w", err)
+		return fmt.Errorf("failed to add finalizer to nodepool: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This update fixes the job check handling when a nodepool is deleted with the dell-hwmgr adaptor. It includes a change to the error response data structure for the job query, as well as adding handling of the possible job status responses.