### PR TITLE
Enhance deletion job check handling

### DIFF
--- a/adaptors/adaptor-interface/interface.go
+++ b/adaptors/adaptor-interface/interface.go
@@ -33,7 +33,7 @@ import (
 type HwMgrAdaptorIntf interface {
 	SetupAdaptor(mgr ctrl.Manager) error
 	HandleNodePool(ctx context.Context, hwmgr *pluginv1alpha1.HardwareManager, nodepool *hwmgmtv1alpha1.NodePool) (ctrl.Result, error)
-	HandleNodePoolDeletion(ctx context.Context, hwmgr *pluginv1alpha1.HardwareManager, nodepool *hwmgmtv1alpha1.NodePool) error
+	HandleNodePoolDeletion(ctx context.Context, hwmgr *pluginv1alpha1.HardwareManager, nodepool *hwmgmtv1alpha1.NodePool) (bool, error)
 	GetResourcePools(ctx context.Context, hwmgr *pluginv1alpha1.HardwareManager) ([]invserver.ResourcePoolInfo, int, error)
 	GetResources(ctx context.Context, hwmgr *pluginv1alpha1.HardwareManager) ([]invserver.ResourceInfo, int, error)
 }

--- a/adaptors/loopback/adaptor.go
+++ b/adaptors/loopback/adaptor.go
@@ -122,14 +122,14 @@ func (a *Adaptor) HandleNodePool(ctx context.Context, hwmgr *pluginv1alpha1.Hard
 	return result, nil
 }
 
-func (a *Adaptor) HandleNodePoolDeletion(ctx context.Context, hwmgr *pluginv1alpha1.HardwareManager, nodepool *hwmgmtv1alpha1.NodePool) error {
+func (a *Adaptor) HandleNodePoolDeletion(ctx context.Context, hwmgr *pluginv1alpha1.HardwareManager, nodepool *hwmgmtv1alpha1.NodePool) (bool, error) {
 	a.Logger.InfoContext(ctx, "Finalizing nodepool")
 
 	if err := a.ReleaseNodePool(ctx, hwmgr, nodepool); err != nil {
-		return fmt.Errorf("failed to release nodepool %s: %w", nodepool.Name, err)
+		return false, fmt.Errorf("failed to release nodepool %s: %w", nodepool.Name, err)
 	}
 
-	return nil
+	return true, nil
 }
 
 func (a *Adaptor) GetResourcePools(ctx context.Context, hwmgr *pluginv1alpha1.HardwareManager) ([]invserver.ResourcePoolInfo, int, error) {

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -45,7 +45,8 @@ const (
 )
 
 const (
-	JobIdAnnotation = "hwmgr-plugin.oran.openshift.io/jobId"
+	JobIdAnnotation         = "hwmgr-plugin.oran.openshift.io/jobId"
+	DeletionJobIdAnnotation = "hwmgr-plugin.oran.openshift.io/deletionJobId"
 )
 
 func UpdateK8sCRStatus(ctx context.Context, c client.Client, object client.Object) error {
@@ -240,6 +241,32 @@ func ClearJobId(object client.Object) {
 	annotations := object.GetAnnotations()
 	if annotations != nil {
 		delete(annotations, JobIdAnnotation)
+	}
+}
+
+func GetDeletionJobId(object client.Object) string {
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+
+	return annotations[DeletionJobIdAnnotation]
+}
+
+func SetDeletionJobId(object client.Object, jobId string) {
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[DeletionJobIdAnnotation] = jobId
+	object.SetAnnotations(annotations)
+}
+
+func ClearDeletionJobId(object client.Object) {
+	annotations := object.GetAnnotations()
+	if annotations != nil {
+		delete(annotations, DeletionJobIdAnnotation)
 	}
 }
 


### PR DESCRIPTION
This update includes the following:
- Improve the job check response handling to differentiate "Not exist" from other failures
- Add separate deletion jobId annotation and requeue for continuing status checks, rather than polling inline
- On deletion, accept "not exist" response for job check to indicate deletion was completed successfully
- At start of deletion handling in the reconciler loop, check hardware manager to see if resource group still exists, as it may have completed deletion already.
- Update nodepool reconciler to use non-caching client for initial Get, to ensure we're not processing a stale CR. This includes ensuring the GVK is set for the CR, which is currently only done by the caching client, but is necessary for patching the CR