### PR TITLE
Update dependabot to ignore github.com/go-git/go-git/v5 until using g…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,9 @@ updates:
     # golang.org/x/oauth2 moved to go 1.23 in 0.27.0, so ignore major/minor updates until this repo is 1.23-based
     - dependency-name: "golang.org/x/oauth2"
       update-types: ["version-update:semver-major","version-update:semver-minor"]
+    # github.com/go-git/go-git/v5 moved to go 1.23 in 5.14.0, so ignore major/minor updates until this repo is 1.23-based
+    - dependency-name: "github.com/go-git/go-git/v5"
+      update-types: ["version-update:semver-major","version-update:semver-minor"]
   #ignore:
   #  - dependency-name: "*"
   #    update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
…o 1.23