### PR TITLE
Fix missing code change in the initial submission

### DIFF
--- a/api/hwmgr-plugin/v1alpha1/hardwaremanager_types.go
+++ b/api/hwmgr-plugin/v1alpha1/hardwaremanager_types.go
@@ -111,7 +111,7 @@ type HardwareManagerSpec struct {
 
 	// The adaptor ID
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=loopback;dell-hwmgr
+	// +kubebuilder:validation:Enum=loopback;dell-hwmgr;metal3
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	AdaptorID HardwareManagerAdaptorID `json:"adaptorId"`
 

--- a/bundle/manifests/hwmgr-plugin.oran.openshift.io_hardwaremanagers.yaml
+++ b/bundle/manifests/hwmgr-plugin.oran.openshift.io_hardwaremanagers.yaml
@@ -66,6 +66,7 @@ spec:
                 enum:
                 - loopback
                 - dell-hwmgr
+                - metal3
                 type: string
               dellData:
                 description: Config data for an instance of the dell-hwmgr adaptor

--- a/config/crd/bases/hwmgr-plugin.oran.openshift.io_hardwaremanagers.yaml
+++ b/config/crd/bases/hwmgr-plugin.oran.openshift.io_hardwaremanagers.yaml
@@ -66,6 +66,7 @@ spec:
                 enum:
                 - loopback
                 - dell-hwmgr
+                - metal3
                 type: string
               dellData:
                 description: Config data for an instance of the dell-hwmgr adaptor

--- a/vendor/github.com/openshift-kni/oran-hwmgr-plugin/api/hwmgr-plugin/v1alpha1/hardwaremanager_types.go
+++ b/vendor/github.com/openshift-kni/oran-hwmgr-plugin/api/hwmgr-plugin/v1alpha1/hardwaremanager_types.go
@@ -111,7 +111,7 @@ type HardwareManagerSpec struct {
 
 	// The adaptor ID
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=loopback;dell-hwmgr
+	// +kubebuilder:validation:Enum=loopback;dell-hwmgr;metal3
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	AdaptorID HardwareManagerAdaptorID `json:"adaptorId"`
 


### PR DESCRIPTION
This commit restores a missing code change that was inadvertently lost in the initial metal3 plugin submission.

The issue was likely caused by reverting some untested code before pushing the previous PR, which caused it to be absent in the test environment but appear in the main branch after the PR merge.