### PR TITLE
CNF-17207 CNF-17208 Refactor hardware profile handling and update node status

### DIFF
--- a/adaptors/metal3/node_allocator.go
+++ b/adaptors/metal3/node_allocator.go
@@ -46,7 +46,7 @@ func (a *Adaptor) allocateBMHToNodePool(ctx context.Context, bmh *metal3v1alpha1
 		},
 		Interfaces: bmhInterface,
 	}
-	updating, err := a.processHwProfile(ctx, bmh, nodeName, false)
+	updating, err := a.processHwProfile(ctx, bmh, group.NodePoolData.HwProfile, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Removed unnecessary GetNode() call during hardware profile processing.

Ensured node status is updated when needed.